### PR TITLE
Bau: restructured gradle build file to follow conventions from other projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,19 @@
 apply from: 'buildSrc/publish.gradle'
 
+ext {
+    opensaml_version = '3.3.0'
+}
+
+def dependencyVersions = [
+        ida_saml_extensions:"$opensaml_version-1.2a-33"
+]
+
 subprojects {
     apply plugin: 'java'
     repositories {
         maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
     }
 
-    ext {
-        opensaml_version = '3.3.0'
-        saml_extensions_version = "$opensaml_version-1.2a-33"
-    }
 
     group = "uk.gov.ida"
     version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
@@ -24,7 +28,7 @@ subprojects {
     }
 
     dependencies {
-        saml "uk.gov.ida:ida-saml-extensions:$saml_extensions_version"
+        saml "uk.gov.ida:ida-saml-extensions:$dependencyVersions.ida_saml_extensions"
 
         opensaml "org.opensaml:opensaml-core:$opensaml_version",
                 'net.shibboleth.utilities:java-support:7.2.0'
@@ -34,7 +38,7 @@ subprojects {
                 'org.assertj:assertj-core:1.6.0',
                 "org.opensaml:opensaml-security-api:$opensaml_version"
 
-        saml_test "uk.gov.ida:ida-saml-extensions-test:$saml_extensions_version",
+        saml_test "uk.gov.ida:ida-saml-extensions-test:$dependencyVersions.ida_saml_extensions",
                 "org.opensaml:opensaml-saml-impl:$opensaml_version",
                 "org.opensaml:opensaml-saml-api:$opensaml_version"
 


### PR DESCRIPTION
This is to facilitate scripting building the saml library chain, as the
lack of standardization makes this messy.

Authors: @timwspence