### PR TITLE
Refactor: use opensaml helpers and break common-utils dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,5 @@ subprojects {
 
         saml_test "org.opensaml:opensaml-saml-impl:$opensaml_version",
                 "org.opensaml:opensaml-saml-api:$opensaml_version"
-
-        common_utils 'uk.gov.ida:common-utils:2.0.0-317',
-                'com.google.guava:guava:18.0'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
 
         test_deps 'org.mockito:mockito-core:1.9.5',
                 'junit:junit:4.11',
-                'org.assertj:assertj-core:1.6.0',
+                'org.assertj:assertj-core:3.9.0',
                 "org.opensaml:opensaml-security-api:$opensaml_version"
 
         saml_test "org.opensaml:opensaml-saml-impl:$opensaml_version",

--- a/saml-serializers/src/main/java/uk/gov/ida/saml/deserializers/ElementToOpenSamlXMLObjectTransformer.java
+++ b/saml-serializers/src/main/java/uk/gov/ida/saml/deserializers/ElementToOpenSamlXMLObjectTransformer.java
@@ -3,9 +3,9 @@ package uk.gov.ida.saml.deserializers;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.w3c.dom.Element;
-import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
 
 import java.util.function.Function;
 

--- a/saml-serializers/src/main/java/uk/gov/ida/saml/deserializers/OpenSamlXMLObjectUnmarshaller.java
+++ b/saml-serializers/src/main/java/uk/gov/ida/saml/deserializers/OpenSamlXMLObjectUnmarshaller.java
@@ -1,14 +1,11 @@
 package uk.gov.ida.saml.deserializers;
 
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.UnmarshallingException;
-import org.xml.sax.SAXException;
-import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
-
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
+import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
 
 import static uk.gov.ida.saml.errors.SamlTransformationErrorFactory.unableToDeserializeStringToOpenSaml;
 
@@ -23,7 +20,7 @@ public class OpenSamlXMLObjectUnmarshaller<TOutput extends XMLObject> {
     public TOutput fromString(String input) {
         try {
             return samlObjectParser.getSamlObject(input);
-        } catch (ParserConfigurationException | SAXException | IOException | UnmarshallingException e) {
+        } catch (UnmarshallingException | XMLParserException  e) {
             SamlValidationSpecificationFailure failure = unableToDeserializeStringToOpenSaml(input);
             throw new SamlTransformationErrorException(failure.getErrorMessage(), e, failure.getLogLevel());
         }

--- a/saml-serializers/src/main/java/uk/gov/ida/saml/deserializers/parser/SamlObjectParser.java
+++ b/saml-serializers/src/main/java/uk/gov/ida/saml/deserializers/parser/SamlObjectParser.java
@@ -1,28 +1,25 @@
 package uk.gov.ida.saml.deserializers.parser;
 
-import net.shibboleth.utilities.java.support.xml.BasicParserPool;
+import net.shibboleth.utilities.java.support.xml.ParserPool;
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.Unmarshaller;
 import org.opensaml.core.xml.io.UnmarshallerFactory;
 import org.opensaml.core.xml.io.UnmarshallingException;
+import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
 
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
-
-import static uk.gov.ida.shared.utils.xml.XmlUtils.convertToElement;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 
 public class SamlObjectParser {
 
-    public <T extends XMLObject> T getSamlObject(String xmlString) throws ParserConfigurationException, SAXException, IOException, UnmarshallingException {
-        BasicParserPool ppMgr = new BasicParserPool();
-        ppMgr.setNamespaceAware(true);
-
-        Element samlRootElement = convertToElement(xmlString);
-
-        return getSamlObject(samlRootElement);
+    @SuppressWarnings("unchecked")
+    public <T extends XMLObject> T getSamlObject(String xmlString) throws UnmarshallingException, XMLParserException {
+        ParserPool parserPool = XMLObjectProviderRegistrySupport.getParserPool();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(xmlString.getBytes(StandardCharsets.UTF_8));
+        return (T) XMLObjectSupport.unmarshallFromInputStream(parserPool, inputStream);
     }
 
     @SuppressWarnings("unchecked")

--- a/saml-serializers/src/main/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoder.java
+++ b/saml-serializers/src/main/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoder.java
@@ -1,8 +1,9 @@
 package uk.gov.ida.saml.deserializers.validators;
 
+import net.shibboleth.utilities.java.support.codec.Base64Support;
+import org.apache.commons.codec.binary.StringUtils;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
-import uk.gov.ida.shared.utils.string.StringEncoding;
 
 import static java.util.regex.Pattern.matches;
 import static uk.gov.ida.saml.errors.SamlTransformationErrorFactory.invalidBase64Encoding;
@@ -16,7 +17,7 @@ public class Base64StringDecoder {
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
 
-        return StringEncoding.fromBase64Encoded(withoutWhitespace);
+        return StringUtils.newStringUtf8(Base64Support.decode(input));
     }
 
 }

--- a/saml-serializers/src/main/java/uk/gov/ida/saml/serializers/XmlObjectToBase64EncodedStringTransformer.java
+++ b/saml-serializers/src/main/java/uk/gov/ida/saml/serializers/XmlObjectToBase64EncodedStringTransformer.java
@@ -1,49 +1,24 @@
 package uk.gov.ida.saml.serializers;
 
-import com.google.common.base.Throwables;
+import net.shibboleth.utilities.java.support.codec.Base64Support;
+import net.shibboleth.utilities.java.support.xml.SerializeSupport;
+import org.apache.commons.codec.binary.StringUtils;
 import org.opensaml.core.xml.XMLObject;
-import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
-import org.opensaml.core.xml.io.Marshaller;
-import org.opensaml.core.xml.io.MarshallerFactory;
-import org.opensaml.core.xml.io.MarshallingException;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import uk.gov.ida.shared.utils.string.StringEncoding;
-import uk.gov.ida.shared.utils.xml.XmlUtils;
 
-import javax.xml.parsers.ParserConfigurationException;
 import java.util.function.Function;
 
 public class XmlObjectToBase64EncodedStringTransformer<TInput extends XMLObject> implements Function<TInput,String> {
 
     @Override
     public String apply(XMLObject signableXMLObject) {
-        String result;
         Element signedElement = marshallToElement(signableXMLObject);
-        result = XmlUtils.writeToString(signedElement);
-        return StringEncoding.toBase64Encoded(result);
+        String node = SerializeSupport.nodeToString(signedElement);
+        return Base64Support.encode(StringUtils.getBytesUtf8(node), Base64Support.UNCHUNKED);
     }
 
     private static Element marshallToElement(XMLObject rootObject) {
-        Element result;
-        try {
-            marshallToXml(rootObject);
-            result = rootObject.getDOM();
-        } catch (ParserConfigurationException | MarshallingException e) {
-            throw Throwables.propagate(e);
-        }
-        return result;
-    }
-
-    private static Document marshallToXml(XMLObject samlXml) throws ParserConfigurationException, MarshallingException {
-        MarshallerFactory marshallerFactory = XMLObjectProviderRegistrySupport.getMarshallerFactory();
-
-        Marshaller responseMarshaller = marshallerFactory.getMarshaller(samlXml);
-
-        Document document = XmlUtils.newDocumentBuilder().newDocument();
-        responseMarshaller.marshall(samlXml, document);
-
-        return document;
+        return new XmlObjectToElementTransformer<>().apply(rootObject);
     }
 
 }

--- a/saml-serializers/src/main/java/uk/gov/ida/saml/serializers/XmlObjectToElementTransformer.java
+++ b/saml-serializers/src/main/java/uk/gov/ida/saml/serializers/XmlObjectToElementTransformer.java
@@ -1,42 +1,20 @@
 package uk.gov.ida.saml.serializers;
 
-import com.google.common.base.Throwables;
 import org.opensaml.core.xml.XMLObject;
-import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
-import org.opensaml.core.xml.io.Marshaller;
-import org.opensaml.core.xml.io.MarshallerFactory;
 import org.opensaml.core.xml.io.MarshallingException;
-import org.w3c.dom.Document;
+import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.w3c.dom.Element;
-
-import javax.xml.parsers.ParserConfigurationException;
 
 import java.util.function.Function;
 
-import static uk.gov.ida.shared.utils.xml.XmlUtils.newDocumentBuilder;
 
 public class XmlObjectToElementTransformer<TInput extends XMLObject> implements Function<TInput,Element> {
 
     public Element apply(TInput rootObject) {
-        Element result;
         try {
-            marshallToXml(rootObject);
-            result = rootObject.getDOM();
-        } catch (ParserConfigurationException | MarshallingException e) {
-            throw Throwables.propagate(e);
+            return XMLObjectSupport.marshall(rootObject);
+        } catch (MarshallingException e) {
+            throw new RuntimeException(e);
         }
-        return result;
     }
-
-    private Document marshallToXml(TInput samlXml) throws ParserConfigurationException, MarshallingException {
-        MarshallerFactory marshallerFactory = XMLObjectProviderRegistrySupport.getMarshallerFactory();
-
-        Marshaller responseMarshaller = marshallerFactory.getMarshaller(samlXml);
-
-        Document document = newDocumentBuilder().newDocument();
-        responseMarshaller.marshall(samlXml, document);
-
-        return document;
-    }
-
 }

--- a/saml-serializers/src/test/java/uk/gov/ida/saml/deserializers/parser/SamlObjectParserTest.java
+++ b/saml-serializers/src/test/java/uk/gov/ida/saml/deserializers/parser/SamlObjectParserTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.saml.deserializers.parser;
 
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,6 +9,7 @@ import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.security.credential.UsageType;
+import org.xml.sax.SAXParseException;
 
 public class SamlObjectParserTest {
 
@@ -21,6 +23,29 @@ public class SamlObjectParserTest {
         SamlObjectParser samlObjectParser = new SamlObjectParser();
         EntityDescriptor samlObject = samlObjectParser.getSamlObject(entityDescriptor);
         Assertions.assertThat(samlObject.getIDPSSODescriptor(SAMLConstants.SAML20P_NS).getKeyDescriptors().get(0).getUse()).isEqualTo(UsageType.SIGNING);
+    }
+
+    @Test
+    public void shouldFailWhenNaughtyXml() {
+        String xmlString = "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE lolz [\n" +
+                " <!ENTITY lol \"lol\">\n" +
+                " <!ELEMENT lolz (#PCDATA)>\n" +
+                " <!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">\n" +
+                " <!ENTITY lol2 \"&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;\">\n" +
+                " <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">\n" +
+                " <!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">\n" +
+                " <!ENTITY lol5 \"&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;\">\n" +
+                " <!ENTITY lol6 \"&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;\">\n" +
+                " <!ENTITY lol7 \"&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;\">\n" +
+                " <!ENTITY lol8 \"&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;\">\n" +
+                " <!ENTITY lol9 \"&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;\">\n" +
+                "]>\n" +
+                "<lolz>&lol9;</lolz>";
+
+        Assertions.assertThatThrownBy(() -> new SamlObjectParser().getSamlObject(xmlString))
+                .hasCauseInstanceOf(SAXParseException.class)
+                .isInstanceOf(XMLParserException.class);
     }
 
     private static final String entityDescriptor = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:ext=\"urn:uk:gov:cabinet-office:tc:saml:metadata:extensions\" cacheDuration=\"PT1M40.000S\" entityID=\"http://stub_idp.acme.org/foo-bar-baz/SSO/POST\" validUntil=\"2012-11-14T14:40:08.224Z\" xsi:type=\"md:EntityDescriptorType\"><ds:Signature xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/><ds:SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha1\"/><ds:Reference URI=\"\"><ds:Transforms><ds:Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/><ds:Transform Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"><ec:InclusiveNamespaces xmlns:ec=\"http://www.w3.org/2001/10/xml-exc-c14n#\" PrefixList=\"xs\"/></ds:Transform></ds:Transforms><ds:DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha1\"/><ds:DigestValue>ziVutS5Scw/+waR24jfJaTkX9aE=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>QovUWDK1LAFiZNdgc4j0E07vpYKHJL7/ylL5kdu314wqvZ+yf6UoRXKGUCnzCxU1cN0sz95E7/vG0N+pl/cuAfvSWpTGbgHhWHTlGWoXBFh7Y4bALKANfE/R8lHIfegAPDI8yuOyquIQPqhFgaz1euVREtmCFNxysfy8UsyoW/g=</ds:SignatureValue></ds:Signature><md:IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\" xsi:type=\"ext:IDPSSODescriptorType\"><md:KeyDescriptor use=\"signing\" xsi:type=\"md:KeyDescriptorType\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xsi:type=\"ds:KeyInfoType\"><ds:X509Data xsi:type=\"ds:X509DataType\"><ds:X509Certificate xsi:type=\"xs:base64Binary\">MIICsDCCAhmgAwIBAgIJAMaC0hPH6QKpMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV\n" +

--- a/saml-serializers/src/test/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoderTest.java
+++ b/saml-serializers/src/test/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoderTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.saml.deserializers.validators;
 
+import org.apache.xml.security.utils.Base64;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,7 +11,6 @@ import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static uk.gov.ida.saml.errors.SamlTransformationErrorFactory.invalidBase64Encoding;
-import static uk.gov.ida.shared.utils.string.StringEncoding.toBase64Encoded;
 
 @RunWith(MockitoJUnitRunner.class)
 public class Base64StringDecoderTest {
@@ -25,6 +25,10 @@ public class Base64StringDecoderTest {
     @Test
     public void shouldPassDecodedStringToNextProcessor() {
         assertThat(samlStringProcessor.decode(toBase64Encoded("string"))).isEqualTo("string");
+    }
+
+    private String toBase64Encoded(String string) {
+        return Base64.encode(string.getBytes());
     }
 
     @Test

--- a/saml-serializers/src/test/java/uk/gov/ida/saml/serializers/XmlObjectToBase64EncodedStringTransformerTest.java
+++ b/saml-serializers/src/test/java/uk/gov/ida/saml/serializers/XmlObjectToBase64EncodedStringTransformerTest.java
@@ -8,7 +8,6 @@ import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.impl.AuthnRequestBuilder;
 
-
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/saml-serializers/src/test/java/uk/gov/ida/saml/serializers/XmlObjectToBase64EncodedStringTransformerTest.java
+++ b/saml-serializers/src/test/java/uk/gov/ida/saml/serializers/XmlObjectToBase64EncodedStringTransformerTest.java
@@ -1,18 +1,21 @@
 package uk.gov.ida.saml.serializers;
 
+import org.apache.commons.codec.binary.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.impl.AuthnRequestBuilder;
-import uk.gov.ida.shared.utils.string.StringEncoding;
+
+
+import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class XmlObjectToBase64EncodedStringTransformerTest {
 
-    private static final String REQUEST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><saml2p:AuthnRequest xmlns:saml2p=\"urn:oasis:names:tc:SAML:2.0:protocol\" Version=\"2.0\"/>";
+    private static final String REQUEST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<saml2p:AuthnRequest Version=\"2.0\" xmlns:saml2p=\"urn:oasis:names:tc:SAML:2.0:protocol\"/>";
 
     private XmlObjectToBase64EncodedStringTransformer xmlObjectToBase64EncodedStringTransformer;
 
@@ -26,7 +29,8 @@ public class XmlObjectToBase64EncodedStringTransformerTest {
     public void shouldTransformAuthnRequestToBase64EncodedString() throws Exception {
         AuthnRequest authnRequest = new AuthnRequestBuilder().buildObject();
 
-        String saml = xmlObjectToBase64EncodedStringTransformer.apply(authnRequest);
-        assertThat(saml).isEqualTo((StringEncoding.toBase64Encoded(REQUEST)));
+        String encodedString = xmlObjectToBase64EncodedStringTransformer.apply(authnRequest);
+        String decoded = StringUtils.newStringUtf8(Base64.getDecoder().decode(StringUtils.getBytesUtf8(encodedString)));
+        assertThat(decoded).isEqualTo(REQUEST);
     }
 }

--- a/saml-serializers/src/test/java/uk/gov/ida/saml/serializers/XmlObjectToElementTransformerTest.java
+++ b/saml-serializers/src/test/java/uk/gov/ida/saml/serializers/XmlObjectToElementTransformerTest.java
@@ -1,0 +1,30 @@
+package uk.gov.ida.saml.serializers;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.core.config.InitializationException;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.impl.AuthnRequestBuilder;
+import org.w3c.dom.Element;
+
+import static org.junit.Assert.*;
+
+public class XmlObjectToElementTransformerTest {
+
+    private static final String REQUEST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><saml2p:AuthnRequest xmlns:saml2p=\"urn:oasis:names:tc:SAML:2.0:protocol\" Version=\"2.0\"/>";
+
+
+    @Before
+    public void setup() throws InitializationException {
+        InitializationService.initialize();
+    }
+
+    @Test
+    public void shouldTransformAuthnRequestToBase64EncodedString() throws Exception {
+        AuthnRequest authnRequest = new AuthnRequestBuilder().buildObject();
+        Element element = new XmlObjectToElementTransformer<>().apply(authnRequest);
+
+    }
+
+}

--- a/saml-serializers/src/test/java/uk/gov/ida/saml/serializers/XmlObjectToElementTransformerTest.java
+++ b/saml-serializers/src/test/java/uk/gov/ida/saml/serializers/XmlObjectToElementTransformerTest.java
@@ -8,12 +8,10 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.impl.AuthnRequestBuilder;
 import org.w3c.dom.Element;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class XmlObjectToElementTransformerTest {
-
-    private static final String REQUEST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><saml2p:AuthnRequest xmlns:saml2p=\"urn:oasis:names:tc:SAML:2.0:protocol\" Version=\"2.0\"/>";
-
 
     @Before
     public void setup() throws InitializationException {
@@ -21,10 +19,10 @@ public class XmlObjectToElementTransformerTest {
     }
 
     @Test
-    public void shouldTransformAuthnRequestToBase64EncodedString() throws Exception {
+    public void shouldTransformObjectToElement() {
         AuthnRequest authnRequest = new AuthnRequestBuilder().buildObject();
         Element element = new XmlObjectToElementTransformer<>().apply(authnRequest);
-
+        assertThat(element.getTagName()).isEqualTo("saml2p:AuthnRequest");
     }
 
 }


### PR DESCRIPTION
THis PR covers some changes to saml-serializers so that we make use of more OpenSAML features rather than our own library code that duplicates it.

Rather using our own libraries for serializing SAML java objects we can
use the libraries that OpenSAML provides:
- `XMLObjectSupport` is used to convert objects into Elements
- `SerializeSupport` is used to convert Elements into Strings
- `Base64Support` is used to base64 encode Strings

Rather than using our own library for base64 decoding we can use
OpenSAML's built in support through `Base64Support`.

We were also using our own helpers for parsing XML from strings and Saml from
XML. This was largely a duplicate of similar code that OpenSAML
provides and in some cases it was doing things less efficiently or with
fewer checks. The key change has been that `SamlObjectParser` will now use
 `XMLObjectSupport` and `ParserPool` to convert from Strings to SAML
 Objects. `SamlObjectParser` will still convert from `Element` to SAML
objects in the same way, but it is unclear whether clients really need
to do this.

All these changes should be backwards compatible with the benefit that common-utils is no longer needed as we're using OpenSAML support helpers for the functions it provided